### PR TITLE
Update Microsoft Writing Style Guide link

### DIFF
--- a/src/pages/contributing/editorial.astro
+++ b/src/pages/contributing/editorial.astro
@@ -724,7 +724,10 @@ Incorrect: "You'll need an antenna, coax and a radio."</code></pre>
       writing
     </li>
     <li>
-      <a href="https://www.arrl.org/style-guide">ARRL Style Guide</a> — Amateur radio terminology
+      <a href="https://www.arrl.org/files/file/QST/This%20Month%20in%20QST/2022/author%20guide%205-24-2022/AUTHOR%202022.pdf">ARRL Author Guide</a> — Author guide for QST articles (PDF)
+    </li>
+    <li>
+      <a href="https://www.arrl.org/ham-radio-glossary">ARRL HAM Radio Glossary</a> — Amateur radio terminology
     </li>
   </ul>
 </DocsLayout>


### PR DESCRIPTION
Existing link is 404.

Note: we could also link directly to the https://learn.microsoft.com/en-us/style-guide/accessibility/accessibility-guidelines-requirements page, not sure if this was the intent given the 'Accessible writing' text next to the link.