### PR TITLE
fix: timezone-aware event sorting and hero priority

### DIFF
--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -10,46 +10,14 @@ import PageLayout from '../../layouts/PageLayout.astro';
 import EventCard from '../../components/event/EventCard.astro';
 import { getCollection } from 'astro:content';
 import { publishedFilter } from '../../utils/content';
-import { getEventTimestampInTimezone, getEventTimezone } from '../../utils/event-time';
-
-// Helper to combine eventDate + startTime into a single timestamp
-// Uses Temporal API for correct timezone handling (Issue #12 fix)
-function getEventTimestamp(event: {
-  data: { eventDate: Date; startTime?: string; venue?: string; timezone?: string };
-}): number {
-  const tz = getEventTimezone(event.data.venue, event.data.timezone);
-  return getEventTimestampInTimezone(event.data.eventDate, event.data.startTime, tz);
-}
-
-// Get end timestamp for multi-day events (end of day on endDate, or same as start for single-day)
-function getEventEndTimestamp(event: {
-  data: { eventDate: Date; endDate?: Date; endTime?: string; venue?: string; timezone?: string };
-}): number {
-  const tz = getEventTimezone(event.data.venue, event.data.timezone);
-  const endDateValue = event.data.endDate || event.data.eventDate;
-
-  if (event.data.endTime) {
-    const timeStr = event.data.endTime;
-    // Check if it's a date string like "2026-02-11" vs time string like "8:00 PM"
-    if (timeStr.match(/^\d{4}-\d{2}-\d{2}/)) {
-      // It's a date string - use end of that day
-      const endDate = new Date(timeStr);
-      return getEventTimestampInTimezone(endDate, '11:59 PM', tz);
-    }
-    // It's a time string
-    return getEventTimestampInTimezone(endDateValue, timeStr, tz);
-  }
-
-  // Default to end of day (11:59 PM)
-  return getEventTimestampInTimezone(endDateValue, '11:59 PM', tz);
-}
+import { getEventStartMs, getEventEndMs } from '../../utils/event-time';
 
 // Get all events sorted by date (we'll split client-side)
 const allEvents = await getCollection('events', publishedFilter);
 type Event = (typeof allEvents)[number];
 
 const sortedEvents = allEvents.sort(
-  (a: Event, b: Event) => getEventTimestamp(a) - getEventTimestamp(b)
+  (a: Event, b: Event) => getEventStartMs(a) - getEventStartMs(b)
 );
 
 // Build time split (will be corrected client-side)
@@ -57,40 +25,39 @@ const now = new Date();
 const nowMs = now.getTime();
 
 // Current: started but not ended
+// Sort by end time ascending — events ending soonest are most immediate
+// (tonight's meeting outranks a month-long DXpedition)
 const currentEvents = sortedEvents
   .filter((event: Event) => {
-    const start = getEventTimestamp(event);
-    const end = getEventEndTimestamp(event);
+    const start = getEventStartMs(event);
+    const end = getEventEndMs(event);
     return start <= nowMs && end >= nowMs;
   })
   .sort((a: Event, b: Event) => {
-    // Featured first, then by date
     if (a.data.featured !== b.data.featured) return a.data.featured ? -1 : 1;
-    return getEventTimestamp(a) - getEventTimestamp(b);
+    return getEventEndMs(a) - getEventEndMs(b);
   });
 
 // Upcoming: not started yet
 const upcomingEvents = sortedEvents
   .filter((event: Event) => {
-    const start = getEventTimestamp(event);
+    const start = getEventStartMs(event);
     return start > nowMs;
   })
   .sort((a: Event, b: Event) => {
-    // Featured first, then by date
     if (a.data.featured !== b.data.featured) return a.data.featured ? -1 : 1;
-    return getEventTimestamp(a) - getEventTimestamp(b);
+    return getEventStartMs(a) - getEventStartMs(b);
   });
 
 // Past: ended
 const pastEvents = sortedEvents
   .filter((event: Event) => {
-    const end = getEventEndTimestamp(event);
+    const end = getEventEndMs(event);
     return end < nowMs;
   })
   .sort((a: Event, b: Event) => {
-    // Featured first, then by date (most recent first for past)
     if (a.data.featured !== b.data.featured) return a.data.featured ? -1 : 1;
-    return getEventTimestamp(b) - getEventTimestamp(a);
+    return getEventStartMs(b) - getEventStartMs(a);
   });
 ---
 
@@ -125,8 +92,8 @@ const pastEvents = sortedEvents
           {
             currentEvents.map((event: Event) => (
               <div
-                data-event-timestamp={getEventTimestamp(event)}
-                data-event-end={getEventEndTimestamp(event)}
+                data-event-timestamp={getEventStartMs(event)}
+                data-event-end={getEventEndMs(event)}
               >
                 <EventCard event={event} variant="horizontal" showJoinButtons />
               </div>
@@ -150,8 +117,8 @@ const pastEvents = sortedEvents
           {
             upcomingEvents.map((event: Event) => (
               <div
-                data-event-timestamp={getEventTimestamp(event)}
-                data-event-end={getEventEndTimestamp(event)}
+                data-event-timestamp={getEventStartMs(event)}
+                data-event-end={getEventEndMs(event)}
               >
                 <EventCard event={event} variant="horizontal" showJoinButtons />
               </div>
@@ -174,8 +141,8 @@ const pastEvents = sortedEvents
           {
             pastEvents.map((event: Event) => (
               <div
-                data-event-timestamp={getEventTimestamp(event)}
-                data-event-end={getEventEndTimestamp(event)}
+                data-event-timestamp={getEventStartMs(event)}
+                data-event-end={getEventEndMs(event)}
               >
                 <EventCard event={event} variant="default" />
               </div>
@@ -227,11 +194,9 @@ const pastEvents = sortedEvents
       }
     });
 
-    // Sort: current and upcoming by soonest first, past by most recent first
+    // Sort: current by ending soonest (most immediate first), upcoming by soonest start, past by most recent
     current.sort(
-      (a, b) =>
-        parseInt(a.dataset.eventTimestamp || '0', 10) -
-        parseInt(b.dataset.eventTimestamp || '0', 10)
+      (a, b) => parseInt(a.dataset.eventEnd || '0', 10) - parseInt(b.dataset.eventEnd || '0', 10)
     );
     upcoming.sort(
       (a, b) =>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,7 @@ import PageLayout from '../layouts/PageLayout.astro';
 import EventCard from '../components/event/EventCard.astro';
 import { getCollection } from 'astro:content';
 import { publishedFilter } from '../utils/content';
+import { getEventStartMs, getEventEndMs } from '../utils/event-time';
 
 // Get all published articles, sorted by date (newest first)
 const allArticles = await getCollection('articles', publishedFilter);
@@ -24,42 +25,36 @@ const allEvents = await getCollection('events', publishedFilter);
 const now = new Date();
 const nowMs = now.getTime();
 
-// Helper to get event end timestamp (end of endDate day, or end of eventDate day)
-function getEventEndMs(event: (typeof allEvents)[number]): number {
-  const endDateValue = event.data.endDate || event.data.eventDate;
-  const date = new Date(endDateValue);
-  date.setHours(23, 59, 59, 999);
-  return date.getTime();
-}
-
 // Current: started but not ended
+// Sort by end time ascending so short-lived events (tonight's meeting) outrank
+// long-running background events (month-long DXpedition). Featured still wins.
 const currentEvents = allEvents
   .filter((event: Event) => {
-    const start = event.data.eventDate.getTime();
+    const start = getEventStartMs(event);
     const end = getEventEndMs(event);
     return start <= nowMs && end >= nowMs;
   })
   .sort((a: Event, b: Event) => {
     if (a.data.featured !== b.data.featured) return a.data.featured ? -1 : 1;
-    return a.data.eventDate.getTime() - b.data.eventDate.getTime();
+    return getEventEndMs(a) - getEventEndMs(b);
   });
 
 // Upcoming: not started yet
 const upcomingEvents = allEvents
-  .filter((event: Event) => event.data.eventDate.getTime() > nowMs)
+  .filter((event: Event) => getEventStartMs(event) > nowMs)
   .sort((a: Event, b: Event) => {
     if (a.data.featured !== b.data.featured) return a.data.featured ? -1 : 1;
-    return a.data.eventDate.getTime() - b.data.eventDate.getTime();
+    return getEventStartMs(a) - getEventStartMs(b);
   });
 
 // Combined for hero selection and grid
 const currentAndUpcoming = [...currentEvents, ...upcomingEvents];
 
-// Hero event: prioritize featured upcoming (soonest), then featured current, then soonest overall
-// This ensures the "next thing to prepare for" gets hero treatment
-const featuredUpcoming = upcomingEvents.find((e: Event) => e.data.featured);
+// Hero event: prioritize featured current (happening now), then featured upcoming, then soonest overall
+// Something happening right now should always outrank a future event
 const featuredCurrent = currentEvents.find((e: Event) => e.data.featured);
-const heroEvent = featuredUpcoming || featuredCurrent || currentAndUpcoming[0];
+const featuredUpcoming = upcomingEvents.find((e: Event) => e.data.featured);
+const heroEvent = featuredCurrent || featuredUpcoming || currentAndUpcoming[0];
 
 // Next 3 events after the hero
 const moreEvents = currentAndUpcoming.filter((e: Event) => e !== heroEvent).slice(0, 3);

--- a/src/utils/event-time.ts
+++ b/src/utils/event-time.ts
@@ -121,6 +121,53 @@ export function formatEventDateTime(
   };
 }
 
+// =============================================================================
+// Event-level timestamp helpers (for sorting / bucketing)
+// =============================================================================
+
+/** Minimal event shape for timestamp computation */
+interface EventTimestampData {
+  data: {
+    eventDate: Date;
+    endDate?: Date;
+    startTime?: string;
+    endTime?: string;
+    venue?: string;
+    timezone?: string;
+  };
+}
+
+/**
+ * Get the UTC start timestamp (ms) for an event.
+ * Combines eventDate + startTime in the event's resolved timezone.
+ * If no startTime, returns start-of-day in the event's timezone.
+ */
+export function getEventStartMs(event: EventTimestampData): number {
+  const tz = getEventTimezone(event.data.venue, event.data.timezone);
+  return getEventTimestampInTimezone(event.data.eventDate, event.data.startTime, tz);
+}
+
+/**
+ * Get the UTC end timestamp (ms) for an event.
+ * Uses endDate (or eventDate) + endTime in the event's resolved timezone.
+ * If no endTime, defaults to 11:59 PM (end of event day).
+ */
+export function getEventEndMs(event: EventTimestampData): number {
+  const tz = getEventTimezone(event.data.venue, event.data.timezone);
+  const endDateValue = event.data.endDate || event.data.eventDate;
+
+  if (event.data.endTime) {
+    return getEventTimestampInTimezone(endDateValue, event.data.endTime, tz);
+  }
+
+  // Default: end of event day in the event's timezone
+  return getEventTimestampInTimezone(endDateValue, '11:59 PM', tz);
+}
+
+// =============================================================================
+// Display formatting
+// =============================================================================
+
 /**
  * Format a compact date/time line for cards and summaries
  * Returns: "Jan 20 · 6:00 PM–8:30 PM PST" or "Jan 20" if no time


### PR DESCRIPTION
Consolidates event timestamp logic to use the Temporal polyfill introduced in #20, and fixes hero selection priority.

### Changes

- **getEventStartMs / getEventEndMs** — new helpers in `event-time.ts` that delegate to `getEventTimestampInTimezone` for correct timezone-aware bucketing into current/upcoming/past
- **Current events sort by end time** — short-lived events (tonight's meeting) outrank long-running background events (month-long DXpedition)
- **Hero selection prefers current over upcoming** — a featured event happening right now takes the hero slot over a future featured event
- **Removed duplicate inline logic** from both `index.astro` and `events/index.astro` in favor of the shared utilities

### Context

The previous inline implementations used `Date.setHours()` which operates in the server's local timezone, causing events to land in the wrong bucket when the build server's timezone differs from the event's timezone. This was the same root cause as #12 but in additional code paths.
