### PR TITLE
feat(home): pin featured articles in Latest; refresh featured set

### DIFF
--- a/src/content/articles/helical-resonator-filters-field-day.md
+++ b/src/content/articles/helical-resonator-filters-field-day.md
@@ -5,7 +5,7 @@ author: 'MicroHAMS'
 date: 2025-10-21
 heroImage: '/images/articles/helical-resonator-filter.jpg'
 tags: ['Field Day', 'HF']
-featured: true
+featured: false
 ---
 
 ## Introduction

--- a/src/content/articles/microhams-field-day-history.md
+++ b/src/content/articles/microhams-field-day-history.md
@@ -4,7 +4,7 @@ description: 'A look back at MicroHAMS Field Day — the rooftop-garage and park
 author: 'MicroHAMS'
 date: 2026-06-14
 draft: false
-featured: false
+featured: true
 tags: ['Field Day', 'HF']
 ---
 

--- a/src/content/articles/spring-2026-dxpeditions.md
+++ b/src/content/articles/spring-2026-dxpeditions.md
@@ -3,7 +3,7 @@ title: 'Spring 2026 DXpeditions: April & May on the Air'
 description: 'A roundup of notable DXpeditions active in April and May 2026, including TX9W to the Marquesas, C5B from the Gambia, and more—right in the peak of Cycle 25 propagation.'
 author: 'MicroHAMS'
 date: 2026-04-14
-featured: true
+featured: false
 tags: ['DX', 'propagation', 'HF']
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -70,16 +70,23 @@ const railEvents = currentAndUpcoming
   .filter((e: Event) => e !== heroEvent && e !== nextMeeting)
   .slice(0, 2);
 
-// Don't surface an article about the very event we're already featuring as
-// the hero (e.g. the Field Day write-up while Field Day is the hero tile).
+// Homepage "Latest": featured articles pin to the top, and a featured
+// article is always kept even if it shares the hero event's topic tag.
+// Otherwise we drop articles that merely echo the hero (e.g. the Field Day
+// write-up while the Field Day event is the hero tile).
 const heroPrimaryTag = heroEvent?.data.tags?.[0]?.toLowerCase();
-const homeArticles = (
-  heroPrimaryTag
-    ? articles.filter(
-        (a: Article) => !(a.data.tags ?? []).some((t: string) => t.toLowerCase() === heroPrimaryTag)
-      )
-    : articles
-).slice(0, 4);
+const homeArticles = articles
+  .filter(
+    (a: Article) =>
+      a.data.featured ||
+      !heroPrimaryTag ||
+      !(a.data.tags ?? []).some((t: string) => t.toLowerCase() === heroPrimaryTag)
+  )
+  .sort((a: Article, b: Article) => {
+    if (a.data.featured !== b.data.featured) return a.data.featured ? -1 : 1;
+    return (b.data.date?.getTime() ?? 0) - (a.data.date?.getTime() ?? 0);
+  })
+  .slice(0, 4);
 
 // Calendar dates render in UTC so a midnight date doesn't shift a day in Pacific
 const fmtDate = (d: Date) =>


### PR DESCRIPTION
Homepage "Latest" now sorts **featured** articles to the top, and a featured article is kept even when it shares the hero event's topic tag (the de-dup still drops non-featured echoes such as `field-day-2026`).

- Feature the **Field Day history** article so it leads "Latest" (it now appears both as the hero event and the lead article — intended).
- Un-feature the **helical resonator** and **spring DXpeditions** pieces; they no longer need pinning.

`astro check` clean; build green (72 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)