### PR TITLE
docs: add CLAUDE.md, refresh AGENTS.md and dev docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 | Concern            | Tool                              |
 | ------------------ | --------------------------------- |
-| Framework          | Astro 5 (static site generator)   |
+| Framework          | Astro 6 (static site generator)   |
 | Language           | TypeScript                        |
 | Styling            | Vanilla CSS (ITCSS architecture)  |
 | Unit tests         | Vitest                            |
@@ -27,7 +27,7 @@
 
 Four Markdown-driven content types, each with Zod-validated schemas:
 
-- **`articles/`** — Technical articles and guides (SDR, digital modes, filters, DXpeditions)
+- **`articles/`** — Technical articles and guides (field day, filters, propagation, DXpeditions)
 - **`docs/`** — Reference documentation (antenna theory, APRS gateways)
 - **`events/`** — Club events and meetings (monthly meetings, field day, swap meets), optionally with images
 - **`pages/`** — Static informational pages (About)
@@ -64,15 +64,25 @@ Four Markdown-driven content types, each with Zod-validated schemas:
 
 ## Common Commands
 
-| Command              | Description                                                  |
-| -------------------- | ------------------------------------------------------------ |
-| `npm run dev`        | Start development server (typically `http://localhost:4321`) |
-| `npm run build`      | Build static site to `dist/`                                 |
-| `npm run preview`    | Preview production build locally                             |
-| `npm test`           | Unit tests in watch mode (Vitest)                            |
-| `npm run test:run`   | Unit tests single run                                        |
-| `npm run test:e2e`   | E2E tests via Playwright (auto-installs browsers if needed)  |
-| `npm run lint`       | Check for lint errors                                        |
-| `npm run lint:fix`   | Auto-fix lint errors                                         |
-| `npm run type-check` | TypeScript + Astro validation                                |
-| `npm run ci`         | Full local validation (lint, types, unit tests, build)       |
+| Command               | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `npm run dev`         | Start development server (typically `http://localhost:4321`)                |
+| `npm run build`       | Build static site to `dist/`                                                |
+| `npm run preview`     | Preview production build locally                                            |
+| `npm test`            | Unit tests in watch mode (Vitest)                                           |
+| `npm run test:run`    | Unit tests single run                                                       |
+| `npm run test:e2e`    | E2E tests via Playwright (auto-installs browsers if needed)                 |
+| `npm run lint`        | Check for lint errors                                                       |
+| `npm run lint:fix`    | Auto-fix lint errors                                                        |
+| `npm run type-check`  | TypeScript + Astro validation                                               |
+| `npm run check:links` | Verify internal links in the built `dist/` (needs a prior `build`)          |
+| `npm run ci`          | Full local validation (verify, lint, types, unit tests, build, check:links) |
+
+---
+
+## Conventions & Gotchas
+
+- **`pre-push` runs the full validation suite** (lint, type-check, content validation, unit tests, build) via a Husky hook — pushes take ~20s and are gated on it passing.
+- **Deploy = publish.** Push or merge to `main` triggers `deploy.yml`; the change is live at [microhams.com](https://microhams.com) within a minute or two. There is no staging environment.
+- **Public repository.** Never commit secrets or personal contact details — git history is permanent and world-readable.
+- **Link checking is internal-only and runs in CI** (`ci.yml` → `check:links`), verifying links resolve within the built site. External-link/URL-rot checking is intentionally out of scope. No third-party GitHub Actions are used.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+@AGENTS.md
+
+## Claude Code notes
+
+- **`gh` accounts:** this repo has multiple GitHub CLI accounts configured. `radiolabme` is the collaborator with write/ADMIN access; `stuffbucket` is READ-only and is often the active account. Run `gh auth switch --user radiolabme` before any PR create/edit/merge, or those calls fail with "must be a collaborator" / "does not have the correct permissions."
+- **`pre-push` runs the full validation suite** (lint, type-check, content validation, unit tests, build — ~20s) via a Husky hook. Pushes are not instant; expect the hook to run and gate the push.
+- **Deploy = publish.** Pushing or merging to `main` triggers `deploy.yml` and the change is live at [microhams.com](https://microhams.com) within a minute or two. There is no staging environment.
+- **Public repository.** Never commit secrets, personal contact details, or anything you would not publish — git history is permanent and world-readable.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,26 +67,27 @@ Playwright is not installed by default. The test commands will prompt for setup 
 
 ### Code Quality
 
-| Command              | Description                   |
-| -------------------- | ----------------------------- |
-| `npm run lint`       | Check for lint errors         |
-| `npm run lint:fix`   | Auto-fix lint errors          |
-| `npm run type-check` | TypeScript + Astro validation |
+| Command               | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `npm run lint`        | Check for lint errors                                |
+| `npm run lint:fix`    | Auto-fix lint errors                                 |
+| `npm run type-check`  | TypeScript + Astro validation                        |
+| `npm run check:links` | Verify internal links in `dist/` (run `build` first) |
 
 ### Validation
 
-| Command            | Description                                       |
-| ------------------ | ------------------------------------------------- |
-| `npm run verify`   | Check package versions + security audit           |
-| `npm run validate` | Design system + accessibility checks              |
-| `npm run ci`       | Local validation (lint, types, unit tests, build) |
+| Command            | Description                                                            |
+| ------------------ | ---------------------------------------------------------------------- |
+| `npm run verify`   | Check package versions + security audit                                |
+| `npm run validate` | Design system + accessibility checks                                   |
+| `npm run ci`       | Local validation (verify, lint, types, unit tests, build, check:links) |
 
 ## Git Hooks
 
 Pre-configured via Husky, run automatically on git operations:
 
 - **pre-commit**: lint-staged (ESLint + Prettier) + `astro check`
-- **pre-push**: full validation suite (lint, type-check, unit tests, build)
+- **pre-push**: full validation suite (lint, type-check, content validation, unit tests, build)
 
 ## Docker
 
@@ -111,11 +112,10 @@ Configuration is in `.docker/`.
 
 ## CI / GitHub Actions
 
-| Workflow         | Trigger               | What it does                     |
-| ---------------- | --------------------- | -------------------------------- |
-| `ci.yml`         | PR and push to `main` | Lint, type-check, unit tests     |
-| `deploy.yml`     | Push to `main`        | Build and deploy to GitHub Pages |
-| `link-check.yml` | Post-deploy + weekly  | Check for broken links           |
+| Workflow     | Trigger               | What it does                                             |
+| ------------ | --------------------- | -------------------------------------------------------- |
+| `ci.yml`     | PR and push to `main` | Lint, type-check, unit tests, build, internal link check |
+| `deploy.yml` | Push to `main`        | Build and deploy to GitHub Pages                         |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Quick links:
 
 ## Deployment
 
-| What           | Where                                                |
-| -------------- | ---------------------------------------------------- |
-| Live site      | [microhams.com](https://microhams.com)               |
-| Hosting        | GitHub Pages                                         |
-| Deploy trigger | Push or merge to `main`                              |
-| CI             | GitHub Actions (build, lint, type-check, unit tests) |
+| What           | Where                                                                     |
+| -------------- | ------------------------------------------------------------------------- |
+| Live site      | [microhams.com](https://microhams.com)                                    |
+| Hosting        | GitHub Pages                                                              |
+| Deploy trigger | Push or merge to `main`                                                   |
+| CI             | GitHub Actions (lint, type-check, unit tests, build, internal link check) |
 
 Deployment status is visible under the [Actions tab](../../actions).
 
@@ -42,12 +42,13 @@ Deployment status is visible under the [Actions tab](../../actions).
 
 ## Automation
 
-| Bot                     | What it does                                                          |
-| ----------------------- | --------------------------------------------------------------------- |
-| **Dependabot**          | Opens a grouped PR each Wednesday with minor/patch dependency updates |
-| **Broken link checker** | Runs after each deploy and weekly; opens an issue if links are broken |
+| Bot            | What it does                                                          |
+| -------------- | --------------------------------------------------------------------- |
+| **Dependabot** | Opens a grouped PR each Wednesday with minor/patch dependency updates |
 
 Dependabot PRs are safe to merge if CI passes. Major version bumps are excluded and handled manually.
+
+Internal links are verified as part of CI (`npm run check:links`) on every PR and push — no separate workflow or third-party action.
 
 ---
 
@@ -60,7 +61,7 @@ src/components/     # Astro components
 src/layouts/        # Page layouts
 src/styles/         # CSS (ITCSS architecture)
 src/site.config.ts  # Venues, recurring meeting links, site-wide settings
-.github/            # CI, deploy, Dependabot, and link-check workflows
+.github/            # CI, deploy, and Dependabot config
 ```
 
 ---


### PR DESCRIPTION
Refreshes project documentation to match the current state and makes the agent context reachable by Claude Code.

## Changes
- **New `CLAUDE.md`** — imports AGENTS.md via `@AGENTS.md` (Claude Code reads `CLAUDE.md`, not `AGENTS.md`, so the existing context was previously invisible to it). Adds a short Claude-Code-specific notes section: `gh` account switching, pre-push behavior, deploy=publish, public-repo hygiene. Single source of truth stays in AGENTS.md.
- **`AGENTS.md`** — corrected Astro 5 → 6, refreshed article examples to current content, documented `check:links`, added a **Conventions & Gotchas** section (pre-push, deploy=publish, public repo, internal-only link checking).
- **`README.md` / `DEVELOPMENT.md`** — removed stale references to the deleted `link-check.yml` workflow; documented that internal link checking now runs inside `ci.yml` via `npm run check:links` (no third-party action). Corrected the `npm run ci` description to include `verify`, `build`, and `check:links`.

## Why the `@import` (not a symlink)
Cross-platform (symlinks are fragile on Windows / some checkouts), explicit, and lets `CLAUDE.md` add Claude-Code-only notes without polluting the tool-neutral `AGENTS.md`.

## Verification
Docs-only. Pre-push suite green (lint, type-check, content validation, unit tests, build).