### PR TITLE
content(events): add July 2026 meeting — Field Day debrief

### DIFF
--- a/src/content/events/2026-07-july-meeting/index.md
+++ b/src/content/events/2026-07-july-meeting/index.md
@@ -1,0 +1,41 @@
+---
+title: 'July Meeting'
+description: 'Monthly MicroHAMS meeting — a Field Day 2026 debrief for our N7OS operation at Camp Freeman, plus an open mic for members to share their own Field Day stories.'
+eventDate: 2026-07-21
+startTime: '6:00 PM'
+endTime: '8:30 PM'
+venue: 'building-31'
+onlineMeeting: 'microhams-teams'
+eventType: 'meeting'
+registrationRequired: false
+draft: false
+featured: false
+tags: ['Field Day']
+---
+
+## Program
+
+### Field Day 2026 Debrief — N7OS at Camp Freeman
+
+This month we look back at **[ARRL Field Day 2026](/events/2026-06-arrl-field-day)**, our N7OS operation at **Camp Freeman near Monroe**. We'll recap how the weekend went — what worked, what we learned, and how the scores shook out:
+
+- **The stations:** how our 3A HF setup and the VHF station performed on the air
+- **Antennas and power:** raising, tuning, and the solar setup that kept the radios running
+- **Bonus points:** satellite contacts, the W1AW bulletin, NTS messages, and the other activities that added up
+- **Lessons learned:** what we'd keep and what we'd change for next year
+
+### Share Your Field Day Story
+
+Field Day is different for everyone, and we want to hear from you. Whether you operated at N7OS, activated from home, chased contacts on the road, or got on the air for the very first time — bring your story. This is an open mic: photos, logs, memorable QSOs, hard-won lessons, and good radio yarns all welcome.
+
+## Meeting Schedule
+
+**6:00 PM - Meeting Begins:**
+
+- Show and Tell (bring your cool things!)
+- Ham Help (bring your questions and challenges!)
+- News and upcoming ham events and activities
+
+**6:30 PM - Presentation:**
+
+- Field Day 2026 Debrief — N7OS at Camp Freeman, and member Field Day stories


### PR DESCRIPTION
Adds the July monthly meeting.

- **When:** Tuesday, July 21, 2026, 6:00 PM
- **Where:** Building 31 (usual location) + Teams
- **Topic:** Field Day 2026 debrief for the N7OS operation at Camp Freeman, plus an open mic for members to share their own Field Day stories

Follows the established monthly-meeting format (schedule block, Teams online meeting, Field Day tag) and links to the existing Field Day event page. Schema validation and internal link check pass.