### PR TITLE
content: add Field Day 2026 results article; refine July invite

### DIFF
--- a/src/content/articles/field-day-2026-results.md
+++ b/src/content/articles/field-day-2026-results.md
@@ -1,0 +1,53 @@
+---
+title: 'Field Day 2026 Results: N7OS Posts 2,224'
+description: 'Operating as N7OS at Camp Freeman, MicroHAMS logged 449 contacts and a preliminary score of 2,224 — up over 2025 in every mode. Club secretary Grant Hopper, KB7WSD, breaks down the numbers and what changes for 2027.'
+author: 'MicroHAMS'
+date: 2026-07-14
+featured: true
+tags: ['Field Day', 'ARRL', 'N7OS']
+---
+
+MicroHAMS operated ARRL Field Day 2026 as **N7OS** from Camp Freeman near Monroe, finishing with **449 logged contacts** and a **preliminary score of 2,224**. Twenty-five participants ran a 3A station on generator, battery, and solar power across the June 27–28 weekend. Contact totals were up over 2025 in every mode, though the club claimed fewer bonus points than the year before.
+
+## The numbers
+
+Contacts earned **627 points** before the power multiplier — 133 on CW, 45 digital, and 271 phone. Running entirely on emergency power qualified N7OS for the 2X multiplier, doubling that to **1,254**. Add **970 bonus points** and the preliminary total comes to **2,224**.
+
+| Band     | CW      | Digital | Phone   |
+| -------- | ------- | ------- | ------- |
+| 80m      | —       | —       | 39      |
+| 40m      | 70      | 45      | 18      |
+| 20m      | —       | —       | 143     |
+| 15m      | 62      | —       | 53      |
+| 10m      | —       | —       | 1       |
+| 6m       | 1       | —       | 9       |
+| 2m       | —       | —       | 8       |
+| **Total** | **133** | **45**  | **271** |
+
+Twenty meters carried the phone effort with 143 contacts, the single busiest band of the weekend. Forty meters did the heavy lifting on CW and digital, accounting for all 45 digital contacts and half the CW total. Fifteen meters came back strong for both CW and phone, and the VHF stations added contacts on 6m and 2m.
+
+The 970 bonus points came from a spread of activities: 300 for running 100% on emergency power, plus 100 each for a public location, a public information table, copying the W1AW Field Day bulletin, completing natural-power contacts, a site visit by an invited served agency, and a safety officer. Youth participation added 20 and the web entry another 50.
+
+## Up across the board
+
+The story of 2026 is a busier station. "When I compare the data to last year, we increased our numbers in almost every way," said club secretary Grant Hopper, KB7WSD. "We had more QSOs overall, and more in every mode."
+
+Band conditions moved the contacts around. More of the action landed on 80 and 15 meters than in past years, which Hopper read as a sign that more people spent more time at the radios. "That sounds like a good thing to me," he said.
+
+## The bonus points left on the table
+
+Against the gains on the air, bonus points came in below 2025 — and Hopper put that squarely on planning. "We did have fewer bonus points, but that's on me," he said. "I didn't do much of a job recruiting for those needs/roles."
+
+He named four areas to target for next year: message handling, social media and publicity, a satellite contact, and an educational activity or demonstration. A visit from an elected official is another standing bonus the club has struggled to land, though Hopper noted the rules don't specify what kind. A commissioner from the water district, for instance, might be a more realistic ask than a legislator, and worth pursuing for 2027.
+
+## Filters and antennas for 2027
+
+The stations performed, but not without friction. With three HF transmitters and a VHF station running at once, transmissions from one radio found their way into others. The club plans to take a closer look at its filters and antenna layout before next year.
+
+"To be sure, they did work very good, but we had some 'edge case' issues that we can probably engineer around for 2027," Hopper said. Reworking the filtering and the spacing between antennas is on the list for the next planning cycle.
+
+## Thanks
+
+"Thank you to everyone that helped and also to everyone that got on the air and contributed to the QSO numbers," Hopper said.
+
+The club will go through the results in person at the **[July meeting](/events/2026-07-july-meeting)** on July 21, and members are invited to bring their own Field Day stories.

--- a/src/content/articles/field-day-2026-results.md
+++ b/src/content/articles/field-day-2026-results.md
@@ -48,7 +48,7 @@ With contact numbers already up across the board, the clearest path to a bigger 
 
 Each of these is worth 100 points, and most come down to lining someone up ahead of the weekend. The official visit, in particular, is more approachable than it sounds: the rules don't specify what kind of official, so a commissioner from the water district or a similar local office is a realistic ask for 2027.
 
-The stations themselves performed well, and there's room to sharpen them too. With three HF transmitters and a VHF station running at once, some signals found their way between radios. "To be sure, they did work very good, but we had some 'edge case' issues that we can probably engineer around for 2027," Hopper said. A closer look at the filtering and antenna spacing is on the list for the next planning cycle.
+The stations themselves performed well, and there's room to sharpen them too. With three HF transmitters and a VHF station running at once, some signals found their way between radios. "To be sure, they did work very well, but we had some 'edge case' issues that we can probably engineer around for 2027," Hopper said. A closer look at the filtering and antenna spacing is on the list for the next planning cycle.
 
 ## Thanks
 

--- a/src/content/articles/field-day-2026-results.md
+++ b/src/content/articles/field-day-2026-results.md
@@ -7,7 +7,7 @@ featured: true
 tags: ['Field Day', 'ARRL', 'N7OS']
 ---
 
-MicroHAMS operated ARRL Field Day 2026 as **N7OS** from Camp Freeman near Monroe, finishing with **449 logged contacts** and a **preliminary score of 2,224**. Twenty-five participants ran a 3A station on generator, battery, and solar power across the June 27–28 weekend. Contact totals were up over 2025 in every mode, though the club claimed fewer bonus points than the year before.
+MicroHAMS operated ARRL Field Day 2026 as **N7OS** from Camp Freeman near Monroe, finishing with **449 logged contacts** and a **preliminary score of 2,224**. Twenty-five participants ran a 3A station on generator, battery, and solar power across the June 27–28 weekend. Contact totals were up over 2025 in every mode, and the club is already lining up new ways to add to the score in 2027.
 
 ## The numbers
 
@@ -34,17 +34,21 @@ The story of 2026 is a busier station. "When I compare the data to last year, we
 
 Band conditions moved the contacts around. More of the action landed on 80 and 15 meters than in past years, which Hopper read as a sign that more people spent more time at the radios. "That sounds like a good thing to me," he said.
 
-## The bonus points left on the table
+## Looking ahead to 2027
 
-Against the gains on the air, bonus points came in below 2025 — and Hopper put that squarely on planning. "We did have fewer bonus points, but that's on me," he said. "I didn't do much of a job recruiting for those needs/roles."
+With contact numbers already up across the board, the clearest path to a bigger score next year runs through the bonus categories — each one a set piece the club can plan for and hand to a volunteer who wants to own it.
 
-He named four areas to target for next year: message handling, social media and publicity, a satellite contact, and an educational activity or demonstration. A visit from an elected official is another standing bonus the club has struggled to land, though Hopper noted the rules don't specify what kind. A commissioner from the water district, for instance, might be a more realistic ask than a legislator, and worth pursuing for 2027.
+> **Open bonus opportunities for 2027**
+>
+> - **Message handling** — pass formal NTS traffic during the event
+> - **Publicity** — a public-information effort and outreach to local media
+> - **Satellite contact** — work a pass for the bonus
+> - **Educational activity** — run a demonstration or class on site
+> - **Served-agency or official visit** — host a guest from a partner agency or local government
 
-## Filters and antennas for 2027
+Each of these is worth 100 points, and most come down to lining someone up ahead of the weekend. The official visit, in particular, is more approachable than it sounds: the rules don't specify what kind of official, so a commissioner from the water district or a similar local office is a realistic ask for 2027.
 
-The stations performed, but not without friction. With three HF transmitters and a VHF station running at once, transmissions from one radio found their way into others. The club plans to take a closer look at its filters and antenna layout before next year.
-
-"To be sure, they did work very good, but we had some 'edge case' issues that we can probably engineer around for 2027," Hopper said. Reworking the filtering and the spacing between antennas is on the list for the next planning cycle.
+The stations themselves performed well, and there's room to sharpen them too. With three HF transmitters and a VHF station running at once, some signals found their way between radios. "To be sure, they did work very good, but we had some 'edge case' issues that we can probably engineer around for 2027," Hopper said. A closer look at the filtering and antenna spacing is on the list for the next planning cycle.
 
 ## Thanks
 

--- a/src/content/events/2026-07-july-meeting/index.md
+++ b/src/content/events/2026-07-july-meeting/index.md
@@ -17,16 +17,13 @@ tags: ['Field Day']
 
 ### Field Day 2026 Debrief — N7OS at Camp Freeman
 
-This month we look back at **[ARRL Field Day 2026](/events/2026-06-arrl-field-day)**, our N7OS operation at **Camp Freeman near Monroe**. We'll recap how the weekend went — what worked, what we learned, and how the scores shook out:
+N7OS finished ARRL Field Day 2026 with **449 contacts** and a preliminary score of **2,224**, up over last year in every mode. This month we'll go through the results together — where the contacts came from, how the stations held up, the bonus points we earned and the ones we left on the table, and the antenna and filter changes we're already planning for 2027.
 
-- **The stations:** how our 3A HF setup and the VHF station performed on the air
-- **Antennas and power:** raising, tuning, and the solar setup that kept the radios running
-- **Bonus points:** satellite contacts, the W1AW bulletin, NTS messages, and the other activities that added up
-- **Lessons learned:** what we'd keep and what we'd change for next year
+The full breakdown is in **[Field Day 2026 Results: N7OS Posts 2,224](/articles/field-day-2026-results)**.
 
-### Share Your Field Day Story
+### Share your Field Day story
 
-Field Day is different for everyone, and we want to hear from you. Whether you operated at N7OS, activated from home, chased contacts on the road, or got on the air for the very first time — bring your story. This is an open mic: photos, logs, memorable QSOs, hard-won lessons, and good radio yarns all welcome.
+Field Day looks different for everyone, and we want to hear it. Whether you operated at Camp Freeman, got on from home, worked the bands mobile, or made your first-ever contact, bring the story. Photos, memorable contacts, and hard-won lessons all welcome — this part of the night is an open mic.
 
 ## Meeting Schedule
 
@@ -38,4 +35,4 @@ Field Day is different for everyone, and we want to hear from you. Whether you o
 
 **6:30 PM - Presentation:**
 
-- Field Day 2026 Debrief — N7OS at Camp Freeman, and member Field Day stories
+- Field Day 2026 debrief and member stories


### PR DESCRIPTION
Splits the N7OS Field Day recap into a dedicated long-form article and tightens the July meeting invite to point at it.

**New article** — `Field Day 2026 Results: N7OS Posts 2,224`
- Nutgraph lead: 449 contacts, 2,224 preliminary score, 3A on emergency power
- Band/mode QSO breakdown table and score components
- Year-over-year analysis (up in every mode; conditions shifted to 80/15m)
- Candid bonus-point accounting and the four roles to recruit for 2027
- Filter/antenna plans for 2027
- Club secretary Grant Hopper, KB7WSD, quoted throughout

**July invite** — now leads with the headline result and links to the article; the open-mic 'share your Field Day story' ask stays.

The invite already merged in #57; this revises it and adds the article. Schema validation, build, and internal link check pass.