### PR TITLE
fix: eliminate nav reload flicker via client routing with persisted WebGL header

### DIFF
--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -4,10 +4,14 @@
  *
  * The main site header with logo, tagline, and navigation.
  * Extracted as a component for composition in different layouts.
+ *
+ * `transition:persist` keeps this whole subtree — including the live WebGL
+ * canvas — as a single DOM node across client-side navigations, so the wave
+ * animation never restarts and the nav never re-inits.
  */
 ---
 
-<header class="site-header">
+<header class="site-header" transition:persist="site-header">
   <div class="scroll-progress" aria-hidden="true"></div>
   <canvas
     class="site-header__wave"
@@ -75,35 +79,14 @@
   // Animated header wave — a few slow sine bands in the brand blue, drawn with
   // WebGL. Progressive enhancement: the static SVG in `.site-header::before`
   // shows if WebGL is unavailable, and reduced-motion renders a single frame.
-  function initHeaderWave() {
-    const canvas = document.querySelector<HTMLCanvasElement>('.site-header__wave');
-    if (!canvas || canvas.dataset.init) return;
-
-    // Fail-in: reveal the static SVG fallback only if WebGL can't take over.
-    const fail = () => canvas.closest('.site-header')?.classList.add('site-header--wave-failed');
-
-    const gl = canvas.getContext('webgl', {
-      alpha: true,
-      premultipliedAlpha: false,
-      antialias: true,
-    });
-    if (!gl) return fail();
-
-    canvas.dataset.init = '1';
-
-    const compile = (type: number, src: string) => {
-      const s = gl.createShader(type)!;
-      gl.shaderSource(s, src);
-      gl.compileShader(s);
-      return gl.getShaderParameter(s, gl.COMPILE_STATUS) ? s : null;
-    };
-    const vs = compile(
-      gl.VERTEX_SHADER,
-      'attribute vec2 p;void main(){gl_Position=vec4(p,0.0,1.0);}'
-    );
-    const fs = compile(
-      gl.FRAGMENT_SHADER,
-      `precision mediump float;
+  //
+  // Because the header is `transition:persist`ed, this canvas normally lives for
+  // the whole session and the animation never restarts across navigations. The
+  // one exception is a lost GL context (some browsers drop it when a canvas is
+  // re-attached during a DOM swap): `build()` re-creates every GL resource on
+  // `webglcontextrestored`, while the loop control lives outside it so a rebuild
+  // can never leave two rAF loops running.
+  const FRAG = `precision mediump float;
        uniform vec2 u_res; uniform float u_time; uniform vec3 u_color; uniform float u_alpha;
        void main(){
          vec2 uv = gl_FragCoord.xy / u_res;                 // uv.y = 1.0 at the top
@@ -140,36 +123,69 @@
          float edge = smoothstep(0.0, 0.04, uv.x) * smoothstep(0.0, 0.04, 1.0 - uv.x);
 
          gl_FragColor = vec4(u_color, clamp(g, 0.0, 1.0) * u_alpha * band * edge);
-       }`
-    );
-    if (!vs || !fs) return fail();
+       }`;
 
-    const prog = gl.createProgram()!;
-    gl.attachShader(prog, vs);
-    gl.attachShader(prog, fs);
-    gl.linkProgram(prog);
-    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) return fail();
-    gl.useProgram(prog);
+  function initHeaderWave() {
+    const canvas = document.querySelector<HTMLCanvasElement>('.site-header__wave');
+    // The one-time wiring (listeners, context-loss handlers) runs once; the
+    // canvas persists across navigations so this guard skips re-wiring.
+    if (!canvas || canvas.dataset.init) return;
+    canvas.dataset.init = '1';
 
-    const buf = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
-    const loc = gl.getAttribLocation(prog, 'p');
-    gl.enableVertexAttribArray(loc);
-    gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+    const fail = () => canvas.closest('.site-header')?.classList.add('site-header--wave-failed');
+    const reduce = matchMedia('(prefers-reduced-motion: reduce)');
 
-    const uRes = gl.getUniformLocation(prog, 'u_res');
-    const uTime = gl.getUniformLocation(prog, 'u_time');
-    const uColor = gl.getUniformLocation(prog, 'u_color');
-    const uAlpha = gl.getUniformLocation(prog, 'u_alpha');
+    let gl: WebGLRenderingContext | null = null;
+    let uRes: WebGLUniformLocation | null = null;
+    let uTime: WebGLUniformLocation | null = null;
+    let uColor: WebGLUniformLocation | null = null;
+    let uAlpha: WebGLUniformLocation | null = null;
+    let raf = 0;
 
-    gl.enable(gl.BLEND);
-    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    // Anchor the wave to a persistent epoch so that on the rare full-page load
+    // (or a context rebuild) it resumes at the phase it would have reached,
+    // rather than snapping back to zero. Elapsed time is wrapped to the shader's
+    // temporal period, so sin() is identical across the wrap (no jump) and
+    // u_time stays small enough for mediump precision.
+    const WAVE_PERIOD = (2 * Math.PI) / 0.45; // matches `u_time * 0.45` in the shader
+    let epoch = Number(sessionStorage.getItem('headerWaveEpoch'));
+    if (!epoch) {
+      epoch = Date.now();
+      try {
+        sessionStorage.setItem('headerWaveEpoch', String(epoch));
+      } catch {
+        /* sessionStorage unavailable (private mode) — continuity is best-effort */
+      }
+    }
+
+    // Per-frame work is ONLY the time uniform + the draw call. Colour and size
+    // change rarely, so they are hoisted out of the loop (observers below).
+    const draw = () => {
+      if (!gl) return;
+      gl.uniform1f(uTime, ((Date.now() - epoch) / 1000) % WAVE_PERIOD);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    };
+    const loop = () => {
+      draw();
+      raf = requestAnimationFrame(loop);
+    };
+    const stop = () => {
+      cancelAnimationFrame(raf);
+      raf = 0;
+    };
+    const start = () => {
+      if (raf || !gl) return;
+      if (reduce.matches) {
+        draw(); // single static frame
+      } else {
+        raf = requestAnimationFrame(loop);
+      }
+    };
 
     const setColor = () => {
-      // Read theme robustly: the router briefly clears <html data-theme> during
-      // a swap, so fall back to the persisted localStorage value (never to the
-      // OS preference) to avoid a colour flip mid-navigation.
+      if (!gl) return;
+      // Read theme robustly: fall back to the persisted localStorage value
+      // (never the OS preference) so a transient data-theme reset can't flip it.
       const stored = document.documentElement.dataset.theme || localStorage.getItem('theme');
       const dark = stored ? stored === 'dark' : matchMedia('(prefers-color-scheme: dark)').matches;
       if (dark) {
@@ -185,6 +201,7 @@
     };
 
     const resize = () => {
+      if (!gl) return;
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
       const w = Math.max(1, Math.round(canvas.clientWidth * dpr));
       const h = Math.max(1, Math.round(canvas.clientHeight * dpr));
@@ -196,50 +213,63 @@
       gl.uniform2f(uRes, w, h);
     };
 
-    // Anchor the wave to a persistent epoch so the animation stays continuous
-    // across full-page navigations. JS state (and rAF's clock) resets on every
-    // load, but the wall clock does not — so deriving u_time from a stored epoch
-    // makes the wave pick up exactly where it left off. Elapsed time is wrapped
-    // to the shader's exact temporal period, so sin() is identical across the
-    // wrap (no jump) and u_time stays small enough for mediump precision.
-    const WAVE_PERIOD = (2 * Math.PI) / 0.45; // matches `u_time * 0.45` in the shader
-    let epoch = Number(sessionStorage.getItem('headerWaveEpoch'));
-    if (!epoch) {
-      epoch = Date.now();
-      try {
-        sessionStorage.setItem('headerWaveEpoch', String(epoch));
-      } catch {
-        /* sessionStorage unavailable (private mode) — continuity is best-effort */
-      }
-    }
+    // (Re)create the GL context and all its resources. Runs on first init and
+    // again on `webglcontextrestored`. Stops any running loop first so a rebuild
+    // never stacks a second rAF loop.
+    const build = () => {
+      stop();
+      gl = canvas.getContext('webgl', { alpha: true, premultipliedAlpha: false, antialias: true });
+      if (!gl) return fail();
 
-    const reduce = matchMedia('(prefers-reduced-motion: reduce)');
-    let raf = 0;
-    // Per-frame work is ONLY the time uniform + the draw call. Colour and size
-    // change rarely, so they are hoisted out of the loop (see setColor/resize
-    // observers below) — reading localStorage or canvas layout every frame was
-    // pure waste that kept the main thread busier than the animation needs.
-    const draw = () => {
-      gl.uniform1f(uTime, ((Date.now() - epoch) / 1000) % WAVE_PERIOD);
-      gl.drawArrays(gl.TRIANGLES, 0, 3);
-    };
-    const loop = () => {
-      draw();
-      raf = requestAnimationFrame(loop);
-    };
-    const start = () => {
-      if (raf) return;
-      if (reduce.matches) {
-        draw(); // single static frame
-      } else {
-        raf = requestAnimationFrame(loop);
-      }
-    };
-    const stop = () => {
-      cancelAnimationFrame(raf);
-      raf = 0;
+      const compile = (type: number, src: string) => {
+        const s = gl!.createShader(type)!;
+        gl!.shaderSource(s, src);
+        gl!.compileShader(s);
+        return gl!.getShaderParameter(s, gl!.COMPILE_STATUS) ? s : null;
+      };
+      const vs = compile(
+        gl.VERTEX_SHADER,
+        'attribute vec2 p;void main(){gl_Position=vec4(p,0.0,1.0);}'
+      );
+      const fs = compile(gl.FRAGMENT_SHADER, FRAG);
+      if (!vs || !fs) return fail();
+
+      const prog = gl.createProgram()!;
+      gl.attachShader(prog, vs);
+      gl.attachShader(prog, fs);
+      gl.linkProgram(prog);
+      if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) return fail();
+      gl.useProgram(prog);
+
+      const bufObj = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, bufObj);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
+      const locP = gl.getAttribLocation(prog, 'p');
+      gl.enableVertexAttribArray(locP);
+      gl.vertexAttribPointer(locP, 2, gl.FLOAT, false, 0, 0);
+
+      uRes = gl.getUniformLocation(prog, 'u_res');
+      uTime = gl.getUniformLocation(prog, 'u_time');
+      uColor = gl.getUniformLocation(prog, 'u_color');
+      uAlpha = gl.getUniformLocation(prog, 'u_alpha');
+
+      gl.enable(gl.BLEND);
+      gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+      resize();
+      setColor();
+      start();
     };
 
+    // Context-loss resilience: prevent default so the browser will fire
+    // `webglcontextrestored`, then rebuild everything when it does.
+    canvas.addEventListener('webglcontextlost', (e) => {
+      e.preventDefault();
+      stop();
+    });
+    canvas.addEventListener('webglcontextrestored', () => build());
+
+    // One-time listeners (registered once; build() is what re-runs on restore).
     document.addEventListener('visibilitychange', () => (document.hidden ? stop() : start()));
     reduce.addEventListener('change', () => {
       stop();
@@ -249,17 +279,12 @@
       resize();
       if (reduce.matches) draw();
     }).observe(canvas);
-
-    // Set colour/size once up front, then update colour only when the theme
-    // attribute actually flips (not every frame).
-    resize();
-    setColor();
     new MutationObserver(() => setColor()).observe(document.documentElement, {
       attributes: true,
       attributeFilter: ['data-theme'],
     });
 
-    start();
+    build();
   }
 
   initHeaderWave();

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -25,7 +25,7 @@ const { title, description, author } = Astro.props;
 <RootLayout title={title} description={description} author={author}>
   <SiteHeader />
 
-  <main class="page-enter">
+  <main>
     <slot />
   </main>
 

--- a/src/layouts/RootLayout.astro
+++ b/src/layouts/RootLayout.astro
@@ -11,11 +11,14 @@
  * Other layouts compose on top of this.
  */
 
-// ClientRouter (SPA view transitions) is intentionally NOT used: its native
-// snapshot renders the live WebGL header canvas as a flat monochrome smear in
-// Safari during the crossfade. We navigate with full-page loads instead, made
-// instant via Astro `prefetch` (see astro.config.mjs) and flicker-free via the
-// static CSS wave baseline + a persistent shader clock in SiteHeader.astro.
+// Client-side routing (Astro ClientRouter): navigation swaps only the page
+// content and PERSISTS the header (`transition:persist` in SiteHeader.astro), so
+// its live WebGL canvas is never destroyed or re-initialised — no reload, no
+// wave restart, no content reflow. All view-transition animations are disabled
+// (see `::view-transition-*` in _components.css) so there is NO crossfade
+// snapshot — which is what previously rendered the WebGL canvas as a monochrome
+// smear on Safari. Swaps are therefore instant.
+import { ClientRouter } from 'astro:transitions';
 
 // Fonts are self-hosted and preloaded via Astro's native Fonts API (configured
 // in astro.config.mjs). <Font> injects the @font-face + metric-matched fallback
@@ -67,7 +70,8 @@ const { title, description = 'MicroHAMS - Amateur Radio Community', author } = A
     <Font cssVariable="--font-atkinson" preload />
     <Font cssVariable="--font-jetbrains" preload />
 
-    {/* No <ClientRouter />: full-page nav + prefetch (see note atop this file). */}
+    {/* Client-side routing: header persists, all VT animations disabled (see note above). */}
+    <ClientRouter />
 
     <title>{title} | MicroHAMS</title>
   </head>

--- a/src/styles/05-components/_components.css
+++ b/src/styles/05-components/_components.css
@@ -310,16 +310,15 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08); /* Subtle elevation */
 }
 
-/* Static SVG wave — the ALWAYS-PAINTED baseline, not a fail-only fallback.
-   Because it is pure CSS, it paints at the new document's FIRST PAINT on every
-   full-page navigation, before the deferred WebGL script has compiled and drawn
-   its first frame. That covers the load gap where the canvas is briefly blank,
-   so the header never flashes to bare surface between pages. The live canvas
-   then layers on top; kept subtle so the canvas reads as the wave and this is
-   just a soft static underlay (and the sole wave if WebGL fails). */
+/* Static SVG wave — fail-only fallback (hidden by default). It is a different
+   shape than the WebGL shader, so painting it as an always-on baseline made it
+   visibly snap to the shader on every full-page reload. It now shows ONLY when
+   WebGL can't initialise (via `.site-header--wave-failed`), so it never competes
+   with the live canvas. The brief pre-canvas frame on load is just the header's
+   own surface colour, which is imperceptible on a fast static load. */
 .site-header::before {
   content: '';
-  display: block;
+  display: none;
   opacity: 0.6;
   position: absolute;
   top: 0;
@@ -356,9 +355,10 @@
   filter: blur(6px);
 }
 
-/* WebGL failure no longer needs to toggle the SVG — it is always painted now.
-   `.site-header--wave-failed` simply means the canvas never draws, leaving the
-   static wave as the only layer, which is exactly the baseline. */
+/* Reveal the static SVG fallback only when WebGL init failed. */
+.site-header--wave-failed::before {
+  display: block;
+}
 
 .site-header__inner {
   display: flex;

--- a/src/styles/05-components/_components.css
+++ b/src/styles/05-components/_components.css
@@ -299,6 +299,18 @@
    Flush left alignment for clarity and modern readability
    ======================================== */
 
+/* Disable EVERY view-transition animation so client-side navigation is an
+   instant swap with no crossfade. This is essential for the persisted WebGL
+   header: the browser cannot rasterise a live GL canvas into a transition
+   snapshot, so any crossfade would flash it blank ("monochrome") on Safari.
+   With zero-duration transitions there is no snapshot window to show — the
+   persisted header (and its running canvas) simply carries straight over. */
+::view-transition-group(*),
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation: none !important;
+}
+
 .site-header {
   position: sticky;
   top: 0;

--- a/src/styles/06-utilities/_motion.css
+++ b/src/styles/06-utilities/_motion.css
@@ -39,32 +39,6 @@
 }
 
 /* ========================================
-   PAGE ENTER — a soft fade + rise on the first paint of each full-page
-   navigation. Because we navigate with full-page loads (no client router), this
-   plays once per page and gently masks the paint hand-off. Animates ONLY opacity
-   and transform — never layout properties — so it cannot cause CLS. The resting
-   state is fully visible, so if motion is disabled the content simply shows with
-   no intro (never left hidden).
-   ======================================== */
-
-@media (prefers-reduced-motion: no-preference) {
-  .page-enter {
-    animation: page-enter 0.42s cubic-bezier(0.16, 1, 0.3, 1) both;
-  }
-}
-
-@keyframes page-enter {
-  from {
-    opacity: 0;
-    transform: translateY(0.75rem);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-/* ========================================
    SCROLL PROGRESS — a thin "tuning" line that fills as the page scrolls
    ======================================== */
 


### PR DESCRIPTION
## Summary

Clicking the logo (or any nav link) was a full-document reload, so the content re-laid-out (a few-px shift) and the WebGL header wave re-initialized (jump/flicker) every time. Adopts the static-site best practice — **client-side routing that persists the shell** — to remove the reload entirely. Verified clean on Safari before merge.

## Changes

- **Client routing** — re-enable Astro `ClientRouter` and `transition:persist` the header, so navigation swaps only the page content. The live WebGL canvas is never destroyed or re-initialized → no reload, no wave restart, no content reflow.
- **No crossfade snapshot** — all view-transition animations disabled (`::view-transition-* { animation: none }`), so there's no snapshot window to render the GL canvas as a monochrome smear on Safari (the reason ClientRouter was removed before). Swaps are instant.
- **Context-loss resilience** — the wave init is now re-entrant and rebuilds its GL resources on `webglcontextrestored` (a canvas re-attach can drop the context on some browsers), with loop control outside the builder so a rebuild never stacks two rAF loops.
- **Removed masking layers** that were fighting the old full-reload model: the `page-enter` transform (the content shift) and the always-on static SVG wave baseline (a different shape than the shader, which snapped on each reload). The SVG is back to a WebGL-fail-only fallback.

## Validation
Full pre-push suite passed: lint, type-check, content validation, unit tests (86), build. Client routing + persist + VT-disable rule confirmed in the built output. Manually verified flicker-free on Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)